### PR TITLE
chore: run renovate on fork, too

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "extends": ["config:base"],
+  "includeForks": true,
   "automerge": true,
   "major": {
     "automerge": false


### PR DESCRIPTION
With this, renovate will run on this repo, too. This is needed since it is a fork.
