### PR TITLE
chore: bump to unreleased version to include bugfix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15835,8 +15835,9 @@
     },
     "node_modules/jschardet": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-3.0.0.tgz",
-      "integrity": "sha512-lJH6tJ77V8Nzd5QWRkFYCLc13a3vADkh3r/Fi8HupZGWk2OVVDfnZP8V/VgQgZ+lzW0kG2UGb5hFgt3V3ndotQ==",
+      "resolved": "git+ssh://git@github.com/aadsm/jschardet.git#a1c060718ae8f273861fc223514004283893ca06",
+      "integrity": "sha512-1t5nKb7H8RFf9/Jsdqu+6LMY+hhUqLvzIg5jJt97SCbSHWPGDw6MvlZYjH6lnRKV7mDQbE8TrcPNZ325Mv3RYg==",
+      "license": "LGPL-2.1+",
       "engines": {
         "node": ">=0.1.90"
       }
@@ -23807,7 +23808,7 @@
         "date-fns": "2.30.0",
         "iban": "0.0.14",
         "iconv-lite": "0.6.3",
-        "jschardet": "3.0.0",
+        "jschardet": "github:aadsm/jschardet#a1c060718ae8f273861fc223514004283893ca06",
         "lodash": "4.17.21",
         "mdn-polyfills": "5.20.0",
         "mt940-js": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -4,5 +4,7 @@
   "devDependencies": {
     "typescript": "5.2.2"
   },
-  "workspaces": ["packages/*"]
+  "workspaces": [
+    "packages/*"
+  ]
 }

--- a/packages/ynap-parsers/package.json
+++ b/packages/ynap-parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@envelope-zero/ynap-parsers",
-  "version": "1.15.13",
+  "version": "1.15.14",
   "description": "Parsers from various formats to YNAB CSV",
   "main": "index.js",
   "author": "Leo Bernard <admin+github@leolabs.org>",
@@ -10,27 +10,27 @@
     "registry": "https://npm.pkg.github.com"
   },
   "dependencies": {
+    "buffer": "6.0.3",
     "date-fns": "2.30.0",
     "iban": "0.0.14",
     "iconv-lite": "0.6.3",
-    "jschardet": "3.0.0",
+    "jschardet": "github:aadsm/jschardet#a1c060718ae8f273861fc223514004283893ca06",
     "lodash": "4.17.21",
     "mdn-polyfills": "5.20.0",
     "mt940-js": "1.0.0",
     "papaparse": "5.4.1",
     "slugify": "1.6.6",
-    "xlsx": "^0.18.0",
-    "buffer": "6.0.3"
+    "xlsx": "^0.18.0"
   },
   "devDependencies": {
+    "@envelope-zero/ynap-bank2ynab-converter": "1.14.9",
     "@types/iban": "0.0.32",
     "@types/jest": "29.5.4",
     "@types/lodash": "4.14.197",
     "@types/papaparse": "5.3.8",
     "fast-glob": "3.3.1",
     "jest": "29.6.2",
-    "ts-jest": "24.3.0",
-    "@envelope-zero/ynap-bank2ynab-converter": "1.14.9"
+    "ts-jest": "24.3.0"
   },
   "scripts": {
     "test": "jest",


### PR DESCRIPTION
This should fix the "TypeError: 1 is read-only" problem we are encountering in https://github.com/envelope-zero/frontend/pull/1044. 

Hopefully.
