### PR TITLE
chore: revert: bump to unreleased version to include bugfix (#121)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15835,9 +15835,8 @@
     },
     "node_modules/jschardet": {
       "version": "3.0.0",
-      "resolved": "git+ssh://git@github.com/aadsm/jschardet.git#a1c060718ae8f273861fc223514004283893ca06",
-      "integrity": "sha512-1t5nKb7H8RFf9/Jsdqu+6LMY+hhUqLvzIg5jJt97SCbSHWPGDw6MvlZYjH6lnRKV7mDQbE8TrcPNZ325Mv3RYg==",
-      "license": "LGPL-2.1+",
+      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-3.0.0.tgz",
+      "integrity": "sha512-lJH6tJ77V8Nzd5QWRkFYCLc13a3vADkh3r/Fi8HupZGWk2OVVDfnZP8V/VgQgZ+lzW0kG2UGb5hFgt3V3ndotQ==",
       "engines": {
         "node": ">=0.1.90"
       }
@@ -23808,7 +23807,7 @@
         "date-fns": "2.30.0",
         "iban": "0.0.14",
         "iconv-lite": "0.6.3",
-        "jschardet": "github:aadsm/jschardet#a1c060718ae8f273861fc223514004283893ca06",
+        "jschardet": "3.0.0",
         "lodash": "4.17.21",
         "mdn-polyfills": "5.20.0",
         "mt940-js": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,5 @@
   "devDependencies": {
     "typescript": "5.2.2"
   },
-  "workspaces": [
-    "packages/*"
-  ]
+  "workspaces": ["packages/*"]
 }

--- a/packages/ynap-parsers/package.json
+++ b/packages/ynap-parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@envelope-zero/ynap-parsers",
-  "version": "1.15.14",
+  "version": "1.15.15",
   "description": "Parsers from various formats to YNAB CSV",
   "main": "index.js",
   "author": "Leo Bernard <admin+github@leolabs.org>",
@@ -10,27 +10,27 @@
     "registry": "https://npm.pkg.github.com"
   },
   "dependencies": {
-    "buffer": "6.0.3",
     "date-fns": "2.30.0",
     "iban": "0.0.14",
     "iconv-lite": "0.6.3",
-    "jschardet": "github:aadsm/jschardet#a1c060718ae8f273861fc223514004283893ca06",
+    "jschardet": "3.0.0",
     "lodash": "4.17.21",
     "mdn-polyfills": "5.20.0",
     "mt940-js": "1.0.0",
     "papaparse": "5.4.1",
     "slugify": "1.6.6",
-    "xlsx": "^0.18.0"
+    "xlsx": "^0.18.0",
+    "buffer": "6.0.3"
   },
   "devDependencies": {
-    "@envelope-zero/ynap-bank2ynab-converter": "1.14.9",
     "@types/iban": "0.0.32",
     "@types/jest": "29.5.4",
     "@types/lodash": "4.14.197",
     "@types/papaparse": "5.3.8",
     "fast-glob": "3.3.1",
     "jest": "29.6.2",
-    "ts-jest": "24.3.0"
+    "ts-jest": "24.3.0",
+    "@envelope-zero/ynap-bank2ynab-converter": "1.14.9"
   },
   "scripts": {
     "test": "jest",


### PR DESCRIPTION
This reverts commit 03330a8de19af3aa69b22908b00c7b3ed98bc1fd and bumps the patch version.

This change is needed since the unreleased version of jschardet contains some bugs.
