### PR TITLE
chore: fix sheetjs version parsing and allowed version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -33,8 +33,9 @@
     {
       "description": "Remove leading v for SheetJS",
       "matchDatasources": ["gitea-tags"],
-      "matchPackageNames": ["xlsx"],
-      "extractVersion": "^v(?<version>.*)$"
+      "matchPackageNames": ["sheetjs/sheetjs"],
+      "extractVersion": "^v(?<version>.*)$",
+      "allowedVersions": "!/^v0.87$/"
     }
   ],
   "customManagers": [


### PR DESCRIPTION
There is a stray `v0.87` tag on the repo that we need to exclude.
The `depName` is also `sheetjs/sheetjs`, not `xlsx`.
