### PR TITLE
fix: enable parsing for all bank2ynab files

### DIFF
--- a/packages/ynap-parsers/package.json
+++ b/packages/ynap-parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@envelope-zero/ynap-parsers",
-  "version": "1.15.28",
+  "version": "1.15.29",
   "description": "Parsers from various formats to YNAB CSV",
   "main": "index.js",
   "author": "Envelope Zero Team <team@envelope-zero.org> (https://envelope-zero.org)",
@@ -10,6 +10,7 @@
     "registry": "https://npm.pkg.github.com"
   },
   "dependencies": {
+    "@envelope-zero/ynap-bank2ynab-converter": "1.14.39",
     "buffer": "6.0.3",
     "date-fns": "2.30.0",
     "iban": "0.0.14",

--- a/packages/ynap-parsers/src/bank2ynab/bank2ynab.spec.ts
+++ b/packages/ynap-parsers/src/bank2ynab/bank2ynab.spec.ts
@@ -1,4 +1,12 @@
-import { calculateInflow, calculateOutflow, parseNumber } from './bank2ynab';
+import {
+  calculateInflow,
+  calculateOutflow,
+  parseNumber,
+  bank2ynab,
+} from './bank2ynab';
+import { glob } from 'glob';
+import fs from 'fs';
+import path from 'path';
 
 describe('bank2ynab Parser Module', () => {
   describe('Number Parser', () => {

--- a/packages/ynap-parsers/src/bank2ynab/bank2ynab.ts
+++ b/packages/ynap-parsers/src/bank2ynab/bank2ynab.ts
@@ -47,7 +47,11 @@ export const calculateInflow = (inflow?: number, outflow?: number) => {
     return outflow < 0 ? -outflow : undefined;
   }
 
-  if (typeof inflow !== 'undefined' && typeof outflow !== 'undefined') {
+  if (
+    typeof inflow !== 'undefined' &&
+    typeof outflow !== 'undefined' &&
+    !(outflow === 0 || inflow === 0)
+  ) {
     throw new Error("Inflow and outflow can't be set simultaneously");
   }
 };
@@ -65,7 +69,11 @@ export const calculateOutflow = (inflow?: number, outflow?: number) => {
     return inflow < 0 ? -inflow : undefined;
   }
 
-  if (typeof outflow !== 'undefined' && typeof inflow !== 'undefined') {
+  if (
+    typeof outflow !== 'undefined' &&
+    typeof inflow !== 'undefined' &&
+    !(outflow === 0 || inflow === 0)
+  ) {
     throw new Error("Inflow and outflow can't be set simultaneously");
   }
 };

--- a/packages/ynap-parsers/src/index.spec.ts
+++ b/packages/ynap-parsers/src/index.spec.ts
@@ -1,4 +1,4 @@
-import { matchFile } from '.';
+import { matchFile, parseFile } from '.';
 import { glob } from 'glob';
 import fs from 'fs';
 import path from 'path';
@@ -22,6 +22,14 @@ describe('Main Module', () => {
         );
       }
       expect(matches.length).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it('should parse all test files', async () => {
+    const files = await glob('**/test-data/*', { absolute: true, cwd: __dirname });
+    for (const fileName of files) {
+      const file = new File([fs.readFileSync(fileName)], path.basename(fileName));
+      const parsed = await parseFile(file);
     }
   });
 });


### PR DESCRIPTION
This fixes a bug where some files couldn't be parsed with the bank2ynab parser.
It also adds testing for all files to be parsed.
