### PR TITLE
fix: remove thousands separator from numbers

### DIFF
--- a/packages/ynap-parsers/package.json
+++ b/packages/ynap-parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@envelope-zero/ynap-parsers",
-  "version": "1.15.30",
+  "version": "1.15.31",
   "description": "Parsers from various formats to YNAB CSV",
   "main": "index.js",
   "author": "Envelope Zero Team <team@envelope-zero.org> (https://envelope-zero.org)",

--- a/packages/ynap-parsers/src/bank2ynab/bank2ynab.ts
+++ b/packages/ynap-parsers/src/bank2ynab/bank2ynab.ts
@@ -18,16 +18,32 @@ export const parseNumber = (input?: string) => {
   }
 
   // Remove all superfluous characters
-  const cleaned = input.replace(/[^\d.,-]/g, '');
+  let cleaned = input.replace(/[^\d.,-]/g, '');
   if (cleaned == '') {
     return NaN;
   }
 
-  try {
-    if (cleaned.includes(',')) {
-      return Number(cleaned.replace(',', '.'));
-    }
+  // If the cleaned string contains both "," and ".", it has
+  // one or more thousands separators AND a decimal separator.
+  // Determine the decimal separator and remove the thousands separator
+  if ([',', '.'].every((term) => cleaned.includes(term))) {
+    const comma = cleaned.indexOf(',');
+    const dot = cleaned.indexOf('.');
 
+    if (dot > comma) {
+      // If "." is used as decimal separator, remove the thousands separators
+      cleaned = cleaned.replace(',', '');
+    } else {
+      // If "," is used as decimal separator, remove the "." as thousands separator
+      cleaned = cleaned.replace('.', '');
+    }
+  }
+
+  // Replace "," as decimal separator with "."
+  cleaned = cleaned.replace(',', '.');
+
+  // Try to cast the string to a number
+  try {
     return Number(cleaned);
   } catch (e) {
     return undefined;

--- a/packages/ynap-parsers/src/bank2ynab/test-data/07-11-2023_Umsatzliste_Girokonto-Abc_DE12345678901234567891.csv
+++ b/packages/ynap-parsers/src/bank2ynab/test-data/07-11-2023_Umsatzliste_Girokonto-Abc_DE12345678901234567891.csv
@@ -4,3 +4,4 @@
 ""
 "Buchungsdatum";"Wertstellung";"Status";"Zahlungspflichtige*r";"Zahlungsempfänger*in";"Verwendungszweck";"Umsatztyp";"Betrag";"Gläubiger-ID";"Mandatsreferenz";"Kundenreferenz"
 "06.11.23";"06.11.23";"Gebucht";"ISSUER";"exampleIssuer";"2023-11-03 Debitk.95 VISA Debit";"Ausgang";"-82,80 €";"";"";"123456789123456"
+"28.09.23";"28.09.23";"Gebucht";"Someone";"Someone Else";"exampleNote";"Eingang";"2.017,32 €";"";"";"123456789012345"


### PR DESCRIPTION
This fixes a bug where the thousands separator, if present, was not removed,
therefore breaking the number parsing.
