### PR TITLE
fix: matching files needs to start at the beginning of the file name

### DIFF
--- a/packages/ynap-parsers/package.json
+++ b/packages/ynap-parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@envelope-zero/ynap-parsers",
-  "version": "1.15.32",
+  "version": "1.15.33",
   "description": "Parsers from various formats to YNAB CSV",
   "main": "index.js",
   "author": "Envelope Zero Team <team@envelope-zero.org> (https://envelope-zero.org)",

--- a/packages/ynap-parsers/src/bank2ynab/bank2ynab.spec.ts
+++ b/packages/ynap-parsers/src/bank2ynab/bank2ynab.spec.ts
@@ -1,12 +1,4 @@
-import {
-  calculateInflow,
-  calculateOutflow,
-  parseNumber,
-  bank2ynab,
-} from './bank2ynab';
-import { glob } from 'glob';
-import fs from 'fs';
-import path from 'path';
+import { calculateInflow, calculateOutflow, parseNumber } from './bank2ynab';
 
 describe('bank2ynab Parser Module', () => {
   describe('Number Parser', () => {

--- a/packages/ynap-parsers/src/bank2ynab/bank2ynab.ts
+++ b/packages/ynap-parsers/src/bank2ynab/bank2ynab.ts
@@ -115,7 +115,7 @@ export const generateParser = (config: ParserConfig) => {
     const content = await readEncodedFile(file);
     const { data } = await parseCsv(content.trim());
 
-    const match = file.name.match(new RegExp(config.filenamePattern));
+    const match = file.name.match(new RegExp(`^${config.filenamePattern}`));
 
     if (!match) {
       return false;


### PR DESCRIPTION
This fixes a bug where more files were matched than they should.
In Python, as taken from bank2ynab, `re.match` matches from the beginning
of the string.

Matching a RegExp in JS does not do that, so we explicitly add the `^` character,
denoting the beginning of the string.
