### PR TITLE
fix: ignore lines with an empty date

### DIFF
--- a/packages/ynap-parsers/package.json
+++ b/packages/ynap-parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@envelope-zero/ynap-parsers",
-  "version": "1.15.35",
+  "version": "1.15.36",
   "description": "Parsers from various formats to YNAB CSV",
   "main": "index.js",
   "author": "Envelope Zero Team <team@envelope-zero.org> (https://envelope-zero.org)",

--- a/packages/ynap-parsers/src/bank2ynab/bank2ynab.ts
+++ b/packages/ynap-parsers/src/bank2ynab/bank2ynab.ts
@@ -132,8 +132,8 @@ export const generateParser = (config: ParserConfig) => {
       return false
     }
 
-    // Get all rows after the header row, filter empty lines, then use the first row of that
-    const row = data.slice(config.headerRows).filter(d => d.length > 1)[0]
+    // Get all rows after the header row, filter empty lines, filter lines without a date (pending transactions), then use the first row of that
+    const row = data.slice(config.headerRows).filter(d => d.length > 1).filter(d => d[columns.Date] != "")[0]
 
     // Check that the date column is set correctly
     try {
@@ -169,8 +169,9 @@ export const generateParser = (config: ParserConfig) => {
     const { data } = await parseCsv(content.trim())
 
     const ynabData = data
-      .slice(config.headerRows, data.length - config.footerRows)
-      .filter(d => d.length > 1)
+      .slice(config.headerRows, data.length - config.footerRows) // Filter header and footer rows
+      .filter(d => d.length > 1) // Filter empty lines
+      .filter(d => d[columns.Date] != "") // Filter lines without date (pending transactions)
       .map(
         d =>
           ({

--- a/packages/ynap-parsers/src/bank2ynab/test-data/07-11-2023_Umsatzliste_Girokonto-Abc_DE12345678901234567891.csv
+++ b/packages/ynap-parsers/src/bank2ynab/test-data/07-11-2023_Umsatzliste_Girokonto-Abc_DE12345678901234567891.csv
@@ -3,5 +3,6 @@
 "Kontostand vom 07.11.2023:";"481,71 EUR"
 ""
 "Buchungsdatum";"Wertstellung";"Status";"Zahlungspflichtige*r";"Zahlungsempfänger*in";"Verwendungszweck";"Umsatztyp";"Betrag";"Gläubiger-ID";"Mandatsreferenz";"Kundenreferenz"
+"17.11.23";"";"Vorgemerkt";"ISSUER";"exampleIssuer";"2023-11-17T09:58 Debitk. 0 ahl.System VISA De bit     (POS)";"Ausgang";"-29,46 €";"";"";"123456789123456"
 "06.11.23";"06.11.23";"Gebucht";"ISSUER";"exampleIssuer";"2023-11-03 Debitk.95 VISA Debit";"Ausgang";"-82,80 €";"";"";"123456789123456"
 "28.09.23";"28.09.23";"Gebucht";"Someone";"Someone Else";"exampleNote";"Eingang";"2.017,32 €";"";"";"123456789012345"


### PR DESCRIPTION
Banks set an empty date for pending transactions. Pending transactions should not be imported until they are really booked by the bank. We need to filter them out once when matching the parser and once when actually parsing the data.