### PR TITLE
ci: publish to npmjs

### DIFF
--- a/.github/workflows/publish-bank2ynab-converter.yml
+++ b/.github/workflows/publish-bank2ynab-converter.yml
@@ -12,27 +12,24 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
 
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
-          node-version: '18.x'
-          registry-url: 'https://npm.pkg.github.com'
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
           cache: npm
           always-auth: true
           cache-dependency-path: package-lock.json
 
       - run: npm install
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: publish bank2-ynab-converter
         run: |
           cd packages/ynap-bank2ynab-converter
           npm run build
-          npm publish
+          npm publish --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-parsers.yml
+++ b/.github/workflows/publish-parsers.yml
@@ -12,22 +12,19 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
 
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
-          node-version: '18.x'
-          registry-url: 'https://npm.pkg.github.com'
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
           cache: npm
           always-auth: true
           cache-dependency-path: package-lock.json
 
       - run: npm install
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: publish parsers
         run: |
@@ -35,6 +32,6 @@ jobs:
           npm run build
           cd ../ynap-parsers
           npm run build
-          npm publish
+          npm publish --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/ynap-bank2ynab-converter/package.json
+++ b/packages/ynap-bank2ynab-converter/package.json
@@ -1,14 +1,11 @@
 {
   "name": "@envelope-zero/ynap-bank2ynab-converter",
-  "version": "1.14.83",
+  "version": "1.14.84",
   "license": "MIT",
   "author": {
-    "email": "admin+github@leolabs.org",
-    "name": "Leo Bernard",
-    "url": "https://leolabs.org"
-  },
-  "publishConfig": {
-    "registry": "https://npm.pkg.github.com"
+    "email": "team@envelope-zero.org",
+    "name": "Envelope Zero Team",
+    "url": "https://envelope-zero.org"
   },
   "bin": "index.js",
   "main": "index.js",

--- a/packages/ynap-parsers/package.json
+++ b/packages/ynap-parsers/package.json
@@ -1,14 +1,15 @@
 {
   "name": "@envelope-zero/ynap-parsers",
-  "version": "1.17.1",
+  "version": "1.17.2",
   "description": "Parsers from various formats to YNAB CSV",
   "main": "index.js",
-  "author": "Envelope Zero Team <team@envelope-zero.org> (https://envelope-zero.org)",
+  "author": {
+    "email": "team@envelope-zero.org",
+    "name": "Envelope Zero Team",
+    "url": "https://envelope-zero.org"
+  },
   "license": "MIT",
   "private": false,
-  "publishConfig": {
-    "registry": "https://npm.pkg.github.com"
-  },
   "dependencies": {
     "@envelope-zero/ynap-bank2ynab-converter": "1.14.39",
     "buffer": "6.0.3",


### PR DESCRIPTION
This changes the package publishing target to npmjs.org.

The main reason for this is that GitHub requires authentication even for public packages, which requires additional steps for contributors that we can avoid.
