### PR TITLE
fix: remove .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-@envelope-zero:registry=https://npm.pkg.github.com

--- a/package-lock.json
+++ b/package-lock.json
@@ -5005,14 +5005,6 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/adler-32": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
-      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -6214,18 +6206,6 @@
         "upper-case-first": "^2.0.2"
       }
     },
-    "node_modules/cfb": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
-      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
-      "dependencies": {
-        "adler-32": "~1.3.0",
-        "crc-32": "~1.2.0"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "license": "MIT",
@@ -6624,14 +6604,6 @@
         "node": ">= 0.12.0"
       }
     },
-    "node_modules/codepage": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
-      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/collect-v8-coverage": {
       "version": "1.0.2",
       "dev": true,
@@ -6889,17 +6861,6 @@
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/crc-32": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
-      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
-      "bin": {
-        "crc32": "bin/crc32.njs"
-      },
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/create-gatsby": {
@@ -9184,14 +9145,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/frac": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
-      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/fraction.js": {
@@ -15805,17 +15758,6 @@
       "version": "1.0.3",
       "license": "BSD-3-Clause"
     },
-    "node_modules/ssf": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
-      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
-      "dependencies": {
-        "frac": "~1.1.2"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/stable": {
       "version": "0.1.8",
       "license": "MIT"
@@ -17482,22 +17424,6 @@
       "version": "2.0.1",
       "license": "MIT"
     },
-    "node_modules/wmf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
-      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/word": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
-      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/workbox-background-sync": {
       "version": "4.3.1",
       "license": "MIT",
@@ -18020,7 +17946,7 @@
     },
     "packages/ynap-bank2ynab-converter": {
       "name": "@envelope-zero/ynap-bank2ynab-converter",
-      "version": "1.14.83",
+      "version": "1.14.85",
       "license": "MIT",
       "dependencies": {
         "commander": "12.0.0",
@@ -18081,10 +18007,10 @@
     },
     "packages/ynap-parsers": {
       "name": "@envelope-zero/ynap-parsers",
-      "version": "1.17.1",
+      "version": "1.17.3",
       "license": "MIT",
       "dependencies": {
-        "@envelope-zero/ynap-bank2ynab-converter": "1.14.39",
+        "@envelope-zero/ynap-bank2ynab-converter": "1.14.85",
         "buffer": "6.0.3",
         "date-fns": "3.3.1",
         "iban": "0.0.14",
@@ -18108,20 +18034,6 @@
         "ts-jest": "29.1.2"
       }
     },
-    "packages/ynap-parsers/node_modules/@envelope-zero/ynap-bank2ynab-converter": {
-      "version": "1.14.39",
-      "resolved": "https://npm.pkg.github.com/download/@envelope-zero/ynap-bank2ynab-converter/1.14.39/e6ae652b9e6f4f4a5a78b4c90f07f7e050f7e9fb",
-      "integrity": "sha512-5ygoRYwfTk8TtGrxou9xRoMuixcv7QcsiyjZsm5lsV25qxhQs6AMaeku/8se+5GGu9/Der2p8BAc1goWlEdVqQ==",
-      "license": "MIT",
-      "dependencies": {
-        "commander": "11.1.0",
-        "encoding": "0.1.13",
-        "node-fetch": "2.7.0"
-      },
-      "bin": {
-        "ynap-bank2ynab-converter": "index.js"
-      }
-    },
     "packages/ynap-parsers/node_modules/brace-expansion": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -18129,14 +18041,6 @@
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
-      }
-    },
-    "packages/ynap-parsers/node_modules/commander": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
-      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
-      "engines": {
-        "node": ">=16"
       }
     },
     "packages/ynap-parsers/node_modules/glob": {
@@ -18180,7 +18084,7 @@
       "version": "1.15.205",
       "license": "MIT",
       "dependencies": {
-        "@envelope-zero/ynap-parsers": "1.15.24",
+        "@envelope-zero/ynap-parsers": "1.17.3",
         "@parcel/watcher": "2.4.1",
         "@types/jest": "29.5.12",
         "@types/node": "20.11.24",
@@ -18216,29 +18120,11 @@
         "tslint": "5.20.1"
       }
     },
-    "packages/ynap-web-app/node_modules/@envelope-zero/ynap-parsers": {
-      "version": "1.15.24",
-      "resolved": "https://npm.pkg.github.com/download/@envelope-zero/ynap-parsers/1.15.24/ac39a9517b2ae25196cd79030ffd029f887f4333",
-      "integrity": "sha512-CMiUbFBFDYTc81dukxQxYuPSuIGwJP4yS1QB2R42xGxzHgm/Tn1n+UQODVGNqBk5q8Xr1a36bp8O8iWGXKismg==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "6.0.3",
-        "date-fns": "2.30.0",
-        "iban": "0.0.14",
-        "iconv-lite": "0.6.3",
-        "jschardet": "3.0.0",
-        "lodash": "4.17.21",
-        "mdn-polyfills": "5.20.0",
-        "mt940-js": "1.0.0",
-        "papaparse": "5.4.1",
-        "slugify": "1.6.6",
-        "xlsx": "0.18.0"
-      }
-    },
     "packages/ynap-web-app/node_modules/@envelope-zero/ynap-parsers/node_modules/date-fns": {
       "version": "2.30.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
       "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "extraneous": true,
       "dependencies": {
         "@babel/runtime": "^7.21.0"
       },
@@ -18290,26 +18176,6 @@
         "@swc/wasm": {
           "optional": true
         }
-      }
-    },
-    "packages/ynap-web-app/node_modules/xlsx": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.0.tgz",
-      "integrity": "sha512-zQluErfRAr7ga2me77sIlDoljSrPCXnrNaiKo2+YFLtGkd0aW0Z9zfARVgNn9nytYBhsEjf6A+H5TogTeddscg==",
-      "dependencies": {
-        "adler-32": "~1.3.0",
-        "cfb": "^1.1.4",
-        "codepage": "~1.15.0",
-        "crc-32": "~1.2.1",
-        "ssf": "~0.11.2",
-        "wmf": "~1.0.1",
-        "word": "~0.3.0"
-      },
-      "bin": {
-        "xlsx": "bin/xlsx.njs"
-      },
-      "engines": {
-        "node": ">=0.8"
       }
     }
   }

--- a/packages/ynap-bank2ynab-converter/package.json
+++ b/packages/ynap-bank2ynab-converter/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@envelope-zero/ynap-bank2ynab-converter",
-  "version": "1.14.84",
+  "version": "1.14.85",
   "license": "MIT",
   "author": {
     "email": "team@envelope-zero.org",
     "name": "Envelope Zero Team",
     "url": "https://envelope-zero.org"
   },
-  "bin": "index.js",
+  "bin": {
+    "ynap-bank2ynab-converter": "index.js"
+  },
   "main": "index.js",
   "scripts": {
     "start": "ts-node src/index.ts",

--- a/packages/ynap-parsers/package.json
+++ b/packages/ynap-parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@envelope-zero/ynap-parsers",
-  "version": "1.17.2",
+  "version": "1.17.3",
   "description": "Parsers from various formats to YNAB CSV",
   "main": "index.js",
   "author": {
@@ -11,7 +11,7 @@
   "license": "MIT",
   "private": false,
   "dependencies": {
-    "@envelope-zero/ynap-bank2ynab-converter": "1.14.39",
+    "@envelope-zero/ynap-bank2ynab-converter": "1.14.85",
     "buffer": "6.0.3",
     "date-fns": "3.3.1",
     "iban": "0.0.14",

--- a/packages/ynap-web-app/package.json
+++ b/packages/ynap-web-app/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "private": true,
   "dependencies": {
-    "@envelope-zero/ynap-parsers": "1.15.24",
+    "@envelope-zero/ynap-parsers": "1.17.3",
     "@parcel/watcher": "2.4.1",
     "@types/jest": "29.5.12",
     "@types/node": "20.11.24",


### PR DESCRIPTION
This removes the .npmrc and bumps package versions again to verify that
the publishing workflow is now successful.

It also bumps the parsers version in the webapp.
